### PR TITLE
Trim the host name.

### DIFF
--- a/PreferencesWindowController.m
+++ b/PreferencesWindowController.m
@@ -40,7 +40,7 @@
 
 - (IBAction)saveButtonPressed:(id)sender {
     PingMenuAppDelegate *AppDelegate = (PingMenuAppDelegate *)[[NSApplication sharedApplication] delegate];
-    AppDelegate.pingHost = self.domain.stringValue;
+    AppDelegate.pingHost = [self.domain.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     [self close];
 }
 


### PR DESCRIPTION
If the user type something like "google.com " the ping will not work. With this change, the host name is trimmed to remove this extra space.
